### PR TITLE
Feature/zoom level setting

### DIFF
--- a/elevation_tile_for_jp_dialog.py
+++ b/elevation_tile_for_jp_dialog.py
@@ -26,6 +26,7 @@ import os
 
 from qgis.PyQt import uic
 from qgis.PyQt import QtWidgets
+from PyQt5.QtCore import Qt
 
 FORM_CLASS, _ = uic.loadUiType(os.path.join(
     os.path.dirname(__file__), 'elevation_tile_for_jp_dialog_base.ui'))
@@ -35,3 +36,4 @@ class ElevationTileforJPDialog(QtWidgets.QDialog, FORM_CLASS):
     def __init__(self, parent=None):
         super(ElevationTileforJPDialog, self).__init__(parent)
         self.setupUi(self)
+        self.setWindowFlags(Qt.WindowStaysOnTopHint)

--- a/get_tiles.py
+++ b/get_tiles.py
@@ -56,11 +56,8 @@ class GetTilesWithinMapCanvas:
         self.dlg.mQgsProjectionSelectionWidget_output_crs.setCrs(
             self.project.crs())
 
-        for i in range(0, 15):
-            self.dlg.comboBox_zoomlevel.addItem(str(i))
-
-        self.dlg.comboBox_zoomlevel.setCurrentText(
-            str(self.get_current_zoom()))
+        # コンボボックスにズームレベルを設定
+        self.setup_zoom_level_combo_box()
 
         # ダイアログのボタンボックスがaccepted（OK）されたらcalcが作動
         self.dlg.button_box.accepted.connect(self.calc)
@@ -150,3 +147,16 @@ class GetTilesWithinMapCanvas:
         upper_right = coord_transform.transform(bbox[2], bbox[3])
 
         return [lower_left.x(), lower_left.y(), upper_right.x(), upper_right.y()]
+
+    # コンボボックスにズームレベルを設定するメソッド
+    def setup_zoom_level_combo_box(self):
+        max_zoom_level = 14
+        current_zoom_level = self.get_current_zoom()
+
+        for i in range(0, max_zoom_level + 1):
+            self.dlg.comboBox_zoomlevel.addItem(str(i))
+
+        if current_zoom_level > max_zoom_level:
+            current_zoom_level = max_zoom_level
+
+        self.dlg.comboBox_zoomlevel.setCurrentText(str(current_zoom_level))


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #26 

### Description
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<!-- 何のために、どのような変更をしますか？ -->

- Always display 14 in the combo box when the zoom level is 14 or higher.
- Always bring dialog to the front.

### Manual Testing
<!-- If manual testing is required, please describe the procedure. -->
<!-- 手動での動作確認が必要なら、そのやり方を記述してください。-->

- Run the plugin with a zoom level of 14 or higher.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ダイアログウィンドウが常に最前面に表示されるようになりました。

- **リファクタ**
  - ズームレベル設定のコードを整理し、新しいメソッドでGUIのズームレベル設定を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->