### PR TITLE
Feat/progress bar

### DIFF
--- a/elevation_tile_tools/elevation_array.py
+++ b/elevation_tile_tools/elevation_array.py
@@ -4,8 +4,6 @@ import numpy as np
 
 
 class ElevationArray:
-    max_number_of_tiles = 1000
-    large_number_of_tiles = 100
 
     def __init__(self, zoom_level, start_path, end_path):
         self.zoom_level = zoom_level

--- a/elevation_tile_tools/elevation_array.py
+++ b/elevation_tile_tools/elevation_array.py
@@ -2,8 +2,6 @@ import urllib
 
 import numpy as np
 
-from PyQt5.QtWidgets import QMessageBox
-
 
 class ElevationArray:
     max_number_of_tiles = 1000
@@ -32,21 +30,5 @@ class ElevationArray:
     def count_tiles(self) -> int:
         number_of_tiles = len(self.x_length) * len(self.y_length)
         print(f"number of tiles:{number_of_tiles}")
-
-        # if number_of_tiles > self.max_number_of_tiles:
-        #     raise TileQuantityException(self.max_number_of_tiles, number_of_tiles)
-        # elif number_of_tiles > self.large_number_of_tiles:
-        #     message = (
-        #         f"取得タイル数({number_of_tiles}枚)が多いため、処理に時間がかかる可能性があります。"
-        #         "ダウンロードを実行しますか？"
-        #     )
-        #     if QMessageBox.No == QMessageBox.question(
-        #         None,
-        #         "確認",
-        #         message,
-        #         QMessageBox.Yes,
-        #         QMessageBox.No,
-        #     ):
-        #         raise UserTerminationException
 
         return number_of_tiles

--- a/elevation_tile_tools/elevation_array.py
+++ b/elevation_tile_tools/elevation_array.py
@@ -28,6 +28,8 @@ class ElevationArray:
         self.zoom_level = zoom_level
         self.start_path = start_path
         self.end_path = end_path
+        self.x_length = range(self.start_path[0], self.end_path[0] + 1)
+        self.y_length = range(self.start_path[1], self.end_path[1] + 1)
 
     # タイル座標から標高タイルを読み込む
     @staticmethod
@@ -41,11 +43,9 @@ class ElevationArray:
         return array
 
     # 範囲内の全ての標高タイルをマージ
-    def fetch_all_tiles(self):
-        x_length = range(self.start_path[0], self.end_path[0] + 1)
-        y_length = range(self.start_path[1], self.end_path[1] + 1)
 
-        number_of_tiles = len(x_length) * len(y_length)
+    def count_tiles(self) -> int:
+        number_of_tiles = len(self.x_length) * len(self.y_length)
         print(f"number of tiles:{number_of_tiles}")
 
         if number_of_tiles > self.max_number_of_tiles:
@@ -64,18 +64,4 @@ class ElevationArray:
             ):
                 raise UserTerminationException
 
-        all_array = np.concatenate(
-            [
-                np.concatenate(
-                    [self.fetch_tile(self.zoom_level, x, y) for y in y_length], axis=0
-                )
-                for x in x_length
-            ],
-            axis=1,
-        )
-
-        if (all_array == -9999).all():
-            raise Exception(
-                "The specified extent is out of range from the provided dem tiles"
-            )
-        return all_array
+        return number_of_tiles

--- a/elevation_tile_tools/elevation_array.py
+++ b/elevation_tile_tools/elevation_array.py
@@ -5,26 +5,11 @@ import numpy as np
 from PyQt5.QtWidgets import QMessageBox
 
 
-class TileQuantityException(Exception):
-    def __init__(self, max_number_of_tiles, number_of_tiles):
-        self.number_of_tiles = number_of_tiles
-        self.max_number_of_tiles = max_number_of_tiles
-
-    def __str__(self):
-        return (
-            f"取得タイル数({self.number_of_tiles}枚)が多すぎます。\n"
-            f"上限の{self.max_number_of_tiles}枚を超えないように取得領域を狭くするか、ズームレベルを小さくしてください。"
-        )
-
-
-class UserTerminationException(Exception):
-    pass
-
-
 class ElevationArray:
+    max_number_of_tiles = 1000
+    large_number_of_tiles = 100
+
     def __init__(self, zoom_level, start_path, end_path):
-        self.max_number_of_tiles = 1000
-        self.large_number_of_tiles = 100
         self.zoom_level = zoom_level
         self.start_path = start_path
         self.end_path = end_path
@@ -48,20 +33,20 @@ class ElevationArray:
         number_of_tiles = len(self.x_length) * len(self.y_length)
         print(f"number of tiles:{number_of_tiles}")
 
-        if number_of_tiles > self.max_number_of_tiles:
-            raise TileQuantityException(self.max_number_of_tiles, number_of_tiles)
-        elif number_of_tiles > self.large_number_of_tiles:
-            message = (
-                f"取得タイル数({number_of_tiles}枚)が多いため、処理に時間がかかる可能性があります。"
-                "ダウンロードを実行しますか？"
-            )
-            if QMessageBox.No == QMessageBox.question(
-                None,
-                "確認",
-                message,
-                QMessageBox.Yes,
-                QMessageBox.No,
-            ):
-                raise UserTerminationException
+        # if number_of_tiles > self.max_number_of_tiles:
+        #     raise TileQuantityException(self.max_number_of_tiles, number_of_tiles)
+        # elif number_of_tiles > self.large_number_of_tiles:
+        #     message = (
+        #         f"取得タイル数({number_of_tiles}枚)が多いため、処理に時間がかかる可能性があります。"
+        #         "ダウンロードを実行しますか？"
+        #     )
+        #     if QMessageBox.No == QMessageBox.question(
+        #         None,
+        #         "確認",
+        #         message,
+        #         QMessageBox.Yes,
+        #         QMessageBox.No,
+        #     ):
+        #         raise UserTerminationException
 
         return number_of_tiles

--- a/elevation_tile_tools/elevation_tile_converter.py
+++ b/elevation_tile_tools/elevation_tile_converter.py
@@ -56,6 +56,7 @@ class ElevationTileConverter(QThread):
         self.number_of_tiles = self.elevation_array.count_tiles()
 
     def set_abort_flag(self, flag=True):
+        # used when abort signal is given
         self.abort_flag = flag
 
     # 緯度経度をWebメルカトルのXY座標に変換

--- a/elevation_tile_tools/elevation_tile_converter.py
+++ b/elevation_tile_tools/elevation_tile_converter.py
@@ -12,11 +12,9 @@ from .geotiff import GeoTiff
 from .tile_coordinate import TileCoordinate
 
 
-class UserTerminationException(Exception):
-    pass
-
-
 class ElevationTileConverter(QThread):
+    # thread signals to progress dialog
+    # use : set maximum value in progress bar: self.setMaximum.emit(110)
     setMaximum = pyqtSignal(int)
     addProgress = pyqtSignal(int)
     postMessage = pyqtSignal(str)
@@ -56,9 +54,6 @@ class ElevationTileConverter(QThread):
 
         self.elevation_array = ElevationArray(self.zoom_level, start_path, end_path)
         self.number_of_tiles = self.elevation_array.count_tiles()
-
-    def set_abort_flag(self, flag=True):
-        self.abort_flag = flag
 
     # 緯度経度をWebメルカトルのXY座標に変換
     @staticmethod

--- a/elevation_tile_tools/elevation_tile_converter.py
+++ b/elevation_tile_tools/elevation_tile_converter.py
@@ -55,6 +55,9 @@ class ElevationTileConverter(QThread):
         self.elevation_array = ElevationArray(self.zoom_level, start_path, end_path)
         self.number_of_tiles = self.elevation_array.count_tiles()
 
+    def set_abort_flag(self, flag=True):
+        self.abort_flag = flag
+
     # 緯度経度をWebメルカトルのXY座標に変換
     @staticmethod
     def transform_latlon_to_xy(latlon):

--- a/elevation_tile_tools/elevation_tile_converter.py
+++ b/elevation_tile_tools/elevation_tile_converter.py
@@ -1,21 +1,33 @@
 from math import atan, exp, pi
 from pathlib import Path
 
+import numpy as np
+
 import pyproj
+
+from PyQt5.QtCore import QThread, pyqtSignal
 
 from .elevation_array import ElevationArray
 from .geotiff import GeoTiff
 from .tile_coordinate import TileCoordinate
 
 
-class ElevationTileConverter:
+class ElevationTileConverter(QThread):
+    setMaximum = pyqtSignal(int)
+    addProgress = pyqtSignal(int)
+    postMessage = pyqtSignal(str)
+    processFinished = pyqtSignal()
+    setAbortable = pyqtSignal(bool)
+    processFailed = pyqtSignal(str)
+
     def __init__(
         self,
         output_path=Path(__file__).parent.parent / "GeoTiff",
         output_crs_id="EPSG:3857",
         zoom_level=10,
-        bbox=None
+        bbox=None,
     ):
+        super().__init__()
         # x_min, y_min, x_max, y_max
         if bbox is None:
             bbox = [
@@ -30,6 +42,9 @@ class ElevationTileConverter:
         self.output_crs_id = output_crs_id
         self.tile_coordinate = TileCoordinate(self.zoom_level, self.bbox)
         self.params_for_creating_geotiff = []
+
+    def set_abort_flag(self, flag=True):
+        self.abort_flag = flag
 
     # 緯度経度をWebメルカトルのXY座標に変換
     @staticmethod
@@ -53,22 +68,20 @@ class ElevationTileConverter:
 
     # タイル座標から、そのタイルの左下・右上の緯度経度を算出
     @staticmethod
-    def tile_to_pixel_coordinate_of_corner(
-            z, x_tile_coordinate, y_tile_coordinate):
+    def tile_to_pixel_coordinate_of_corner(z, x_tile_coordinate, y_tile_coordinate):
         # 楕円体の長半径
         ellipsoid_radius = 6378137
         # タイル原点(0,0)のXY座標
         org_x = -1 * (2 * ellipsoid_radius * pi / 2)
         org_y = 2 * ellipsoid_radius * pi / 2
         # 楕円体の円周をタイルの枚数で割ってタイル1枚の距離を算出
-        unit = 2 * ellipsoid_radius * pi / (2 ** z)
+        unit = 2 * ellipsoid_radius * pi / (2**z)
         # タイルの原点からタイル座標までの距離を算出
         x = org_x + x_tile_coordinate * unit
         y = org_y - y_tile_coordinate * unit
 
         # 左下・右上の緯度経度を算出
-        lower_left_lat = atan(
-            exp((y - unit) * pi / 20037508.34)) * 360 / pi - 90
+        lower_left_lat = atan(exp((y - unit) * pi / 20037508.34)) * 360 / pi - 90
         lower_left_lon = x * 180 / 20037508.34
         lower_left_latlon = [lower_left_lat, lower_left_lon]
 
@@ -79,12 +92,36 @@ class ElevationTileConverter:
         return lower_left_latlon, upper_right_latlon
 
     # 一括処理を行うメソッド
-    def calc(self):
-        start_path, end_path, lower_left_tile_path, upper_light_tile_path = self.tile_coordinate.calc_tile_coordinates()
+    def run(self):
+        start_path, end_path, lower_left_tile_path, upper_light_tile_path = (
+            self.tile_coordinate.calc_tile_coordinates()
+        )
 
-        self.elevation_array = ElevationArray(
-            self.zoom_level, start_path, end_path)
-        np_array = self.elevation_array.fetch_all_tiles()
+        self.elevation_array = ElevationArray(self.zoom_level, start_path, end_path)
+        number_of_tiles = self.elevation_array.count_tiles()
+        self.setMaximum.emit(number_of_tiles)
+        self.postMessage.emit("集計中")
+        self.setAbortable.emit(True)
+
+        # get elevation tile arrays
+        tiles = []
+        for x in self.elevation_array.x_length:
+            row_tiles = []
+            for y in self.elevation_array.y_length:
+                tile = self.elevation_array.fetch_tile(self.zoom_level, x, y)
+                row_tiles.append(tile)
+                self.addProgress.emit(1)
+            tiles.append(np.concatenate(row_tiles, axis=0))
+
+        np_array = np.concatenate(tiles, axis=1)
+
+        if (np_array == -9999).all():
+            raise Exception(
+                "The specified extent is out of range from the provided dem tiles"
+            )
+
+        self.postMessage.emit("終了処理中")
+
         x_length = np_array.shape[1]
         y_length = np_array.shape[0]
 
@@ -103,26 +140,18 @@ class ElevationTileConverter:
         pixel_size_x = None
         pixel_size_y = None
         if upper_right_XY[0] >= 0 and lower_left_XY[0] >= 0:
-            pixel_size_x = (
-                abs(upper_right_XY[0]) - abs(lower_left_XY[0])) / x_length
-            pixel_size_y = - \
-                (abs(upper_right_XY[1]) - abs(lower_left_XY[1])) / y_length
+            pixel_size_x = (abs(upper_right_XY[0]) - abs(lower_left_XY[0])) / x_length
+            pixel_size_y = -(abs(upper_right_XY[1]) - abs(lower_left_XY[1])) / y_length
         elif upper_right_XY[0] <= 0 and lower_left_XY[0] <= 0:
-            pixel_size_x = (
-                abs(upper_right_XY[0]) - abs(lower_left_XY[0])) / x_length
-            pixel_size_y = - \
-                (abs(upper_right_XY[1]) - abs(lower_left_XY[1])) / y_length
+            pixel_size_x = (abs(upper_right_XY[0]) - abs(lower_left_XY[0])) / x_length
+            pixel_size_y = -(abs(upper_right_XY[1]) - abs(lower_left_XY[1])) / y_length
         # 片方がプラスなら絶対値を足す
         elif upper_right_XY[0] <= 0 <= lower_left_XY[0]:
-            pixel_size_x = (
-                abs(upper_right_XY[0]) + abs(lower_left_XY[0])) / x_length
-            pixel_size_y = - \
-                (abs(upper_right_XY[1]) + abs(lower_left_XY[1])) / y_length
+            pixel_size_x = (abs(upper_right_XY[0]) + abs(lower_left_XY[0])) / x_length
+            pixel_size_y = -(abs(upper_right_XY[1]) + abs(lower_left_XY[1])) / y_length
         elif upper_right_XY[0] >= 0 >= lower_left_XY[0]:
-            pixel_size_x = (
-                abs(upper_right_XY[0]) + abs(lower_left_XY[0])) / x_length
-            pixel_size_y = - \
-                (abs(upper_right_XY[1]) + abs(lower_left_XY[1])) / y_length
+            pixel_size_x = (abs(upper_right_XY[0]) + abs(lower_left_XY[0])) / x_length
+            pixel_size_y = -(abs(upper_right_XY[1]) + abs(lower_left_XY[1])) / y_length
 
         self.params_for_creating_geotiff = [
             np_array,
@@ -147,3 +176,5 @@ class ElevationTileConverter:
 
         if not self.output_crs_id == "EPSG:3857":
             geotiff.reprojection("EPSG:3857", self.output_crs_id)
+
+        self.processFinished.emit()

--- a/elevation_tile_tools/elevation_tile_converter.py
+++ b/elevation_tile_tools/elevation_tile_converter.py
@@ -23,6 +23,7 @@ class ElevationTileConverter(QThread):
     postMessage = pyqtSignal(str)
     processFinished = pyqtSignal()
     setAbortable = pyqtSignal(bool)
+    warningTiles = pyqtSignal(str)
     processFailed = pyqtSignal(str)
 
     def __init__(
@@ -106,9 +107,9 @@ class ElevationTileConverter(QThread):
         number_of_tiles = self.elevation_array.count_tiles()
 
         # check number of tiles
-        print("tt", self.elevation_array.max_number_of_tiles)
+
         if number_of_tiles > self.elevation_array.max_number_of_tiles:
-            print("over", self.elevation_array.max_number_of_tiles)
+
             error_message = (
                 f"取得タイル数({number_of_tiles}枚)が多すぎます。\n"
                 f"上限の{self.elevation_array.max_number_of_tiles}枚を超えないように取得領域を狭くするか、ズームレベルを小さくしてください。"
@@ -119,22 +120,12 @@ class ElevationTileConverter(QThread):
             #     self.elevation_array.max_number_of_tiles, number_of_tiles
             # )
 
-        # elif number_of_tiles > self.large_number_of_tiles:
-
-        #     message = (
-        #         f"取得タイル数({number_of_tiles}枚)が多いため、処理に時間がかかる可能性があります。"
-        #         "ダウンロードを実行しますか？"
-        #     )
-        #     print(message)
-        #     if QMessageBox.No == QMessageBox.question(
-        #         None,
-        #         "確認",
-        #         message,
-        #         QMessageBox.Yes,
-        #         QMessageBox.No,
-        #     ):
-        #         self.processFinished.emit()
-        #         return
+        elif number_of_tiles > self.elevation_array.large_number_of_tiles:
+            message = (
+                f"取得タイル数({number_of_tiles}枚)が多いため、処理に時間がかかる可能性があります。"
+                "ダウンロードを実行しますか？"
+            )
+            self.warningTiles.emit(message)
 
         self.setMaximum.emit(number_of_tiles)
         self.postMessage.emit("集計中")

--- a/elevation_tile_tools/elevation_tile_converter.py
+++ b/elevation_tile_tools/elevation_tile_converter.py
@@ -154,17 +154,16 @@ class ElevationTileConverter(QThread):
         # どっちもプラス、マイナスなら、絶対値の大きい方から小さい方を引く
         pixel_size_x = None
         pixel_size_y = None
-        if upper_right_XY[0] >= 0 and lower_left_XY[0] >= 0:
-            pixel_size_x = (abs(upper_right_XY[0]) - abs(lower_left_XY[0])) / x_length
-            pixel_size_y = -(abs(upper_right_XY[1]) - abs(lower_left_XY[1])) / y_length
-        elif upper_right_XY[0] <= 0 and lower_left_XY[0] <= 0:
+
+        if (upper_right_XY[0] >= 0 and lower_left_XY[0] >= 0) or (
+            upper_right_XY[0] <= 0 and lower_left_XY[0] <= 0
+        ):
             pixel_size_x = (abs(upper_right_XY[0]) - abs(lower_left_XY[0])) / x_length
             pixel_size_y = -(abs(upper_right_XY[1]) - abs(lower_left_XY[1])) / y_length
         # 片方がプラスなら絶対値を足す
-        elif upper_right_XY[0] <= 0 <= lower_left_XY[0]:
-            pixel_size_x = (abs(upper_right_XY[0]) + abs(lower_left_XY[0])) / x_length
-            pixel_size_y = -(abs(upper_right_XY[1]) + abs(lower_left_XY[1])) / y_length
-        elif upper_right_XY[0] >= 0 >= lower_left_XY[0]:
+        elif (upper_right_XY[0] <= 0 <= lower_left_XY[0]) or (
+            upper_right_XY[0] >= 0 >= lower_left_XY[0]
+        ):
             pixel_size_x = (abs(upper_right_XY[0]) + abs(lower_left_XY[0])) / x_length
             pixel_size_y = -(abs(upper_right_XY[1]) + abs(lower_left_XY[1])) / y_length
 

--- a/elevation_tile_tools/elevation_tile_converter.py
+++ b/elevation_tile_tools/elevation_tile_converter.py
@@ -5,7 +5,6 @@ import numpy as np
 
 import pyproj
 
-from PyQt5.QtWidgets import QMessageBox
 from PyQt5.QtCore import QThread, pyqtSignal
 
 from .elevation_array import ElevationArray
@@ -114,11 +113,7 @@ class ElevationTileConverter(QThread):
                 f"取得タイル数({number_of_tiles}枚)が多すぎます。\n"
                 f"上限の{self.elevation_array.max_number_of_tiles}枚を超えないように取得領域を狭くするか、ズームレベルを小さくしてください。"
             )
-            # QMessageBox.information(None, "Error", error_message)
             self.processFailed.emit(error_message)
-            # raise TileQuantityException(
-            #     self.elevation_array.max_number_of_tiles, number_of_tiles
-            # )
 
         elif number_of_tiles > self.elevation_array.large_number_of_tiles:
             message = (

--- a/get_tiles.py
+++ b/get_tiles.py
@@ -35,8 +35,7 @@ from qgis.gui import QgsFileWidget
 from elevation_tile_for_jp_dialog import ElevationTileforJPDialog
 
 from elevation_tile_tools import ElevationTileConverter
-from elevation_tile_tools.elevation_array import (
-    TileQuantityException,
+from elevation_tile_tools.elevation_tile_converter import (
     UserTerminationException,
 )
 
@@ -136,18 +135,16 @@ class GetTilesWithinMapCanvas:
         thread.setAbortable.connect(progress_dialog.set_abortable)
         thread.processFinished.connect(progress_dialog.close)
         thread.processFailed.connect(
-            lambda error_message: QMessageBox.information(
-                self.main, "エラー", f"エラーが発生しました。\n\n{error_message}"
-            )
+            lambda error_message: [
+                progress_dialog.close(),
+                QMessageBox.information(None, "エラー", error_message),
+            ]
         )
 
         # 処理の実行
         try:
             thread.start()
             progress_dialog.exec_()
-        except TileQuantityException as e:
-            QMessageBox.information(None, "Error", str(e))
-            return
         except UserTerminationException:
             return
 

--- a/get_tiles.py
+++ b/get_tiles.py
@@ -134,6 +134,7 @@ class GetTilesWithinMapCanvas:
         thread.postMessage.connect(progress_dialog.set_message)
         thread.setAbortable.connect(progress_dialog.set_abortable)
         thread.processFinished.connect(progress_dialog.close)
+        thread.warningTiles.connect(progress_dialog.warning_tiles)
         thread.processFailed.connect(
             lambda error_message: [
                 progress_dialog.close(),

--- a/get_tiles.py
+++ b/get_tiles.py
@@ -113,7 +113,8 @@ class GetTilesWithinMapCanvas:
 
     def abort_process(self, thread, progress_dialog):
         if self.process_interrupted:
-            thread.terminate()
+            # thread.terminate()
+            thread.exit()
             progress_dialog.abort_dialog()
             self.dlg_cancel()
             return

--- a/get_tiles.py
+++ b/get_tiles.py
@@ -103,7 +103,6 @@ class GetTilesWithinMapCanvas:
 
     def abort_process(self, thread, progress_dialog):
         if self.process_interrupted:
-            # thread.terminate()
             thread.exit()
             progress_dialog.abort_dialog()
             self.dlg_cancel()
@@ -195,13 +194,16 @@ class GetTilesWithinMapCanvas:
             ]
         )
 
-        # 処理の実行
+        # タイル取得処理の実行
         thread.start()
         progress_dialog.exec_()
 
         # do not import if processed has been interrupted
         if self.process_interrupted:
             return
+
+        # Tiffを作成
+        thread.create_geotiff()
 
         # 出力ファイルをマップキャンバスに追加する
         self.project.addMapLayer(

--- a/progress_dialog.py
+++ b/progress_dialog.py
@@ -30,7 +30,6 @@ class ProgressDialog(QDialog):
         self.progressBar.setMaximum(0)
         self.abortButton.setEnabled(True)
         self.abortButton.setText("中断")
-        self.abortButton.clicked.connect(self.on_abort_click)
 
     def keyPressEvent(self, event: QKeyEvent):
         if event.key() == Qt.Key_Escape:
@@ -51,19 +50,12 @@ class ProgressDialog(QDialog):
                 self.abortButton.setText("中断待機中...")
                 self.close()
 
-    def warning_tiles(self, message):
-        if QMessageBox.No == QMessageBox.question(
-            self,
-            "確認",
-            message,
-            QMessageBox.Yes,
-            QMessageBox.No,
-        ):
-            if self.abortButton.isEnabled():  # abort if possible
-                self.set_abort_flag_callback()
-                self.abortButton.setEnabled(False)
-                self.abortButton.setText("中断待機中...")
-                self.close()
+    def abort_dialog(self):
+        if self.abortButton.isEnabled():  # abort if possible
+            self.set_abort_flag_callback()
+            self.abortButton.setEnabled(False)
+            self.abortButton.setText("中断待機中...")
+            self.close()
 
     def set_maximum(self, value: int):
         self.progressBar.setMaximum(value)

--- a/progress_dialog.py
+++ b/progress_dialog.py
@@ -49,6 +49,7 @@ class ProgressDialog(QDialog):
                 self.set_abort_flag_callback()
                 self.abortButton.setEnabled(False)
                 self.abortButton.setText("中断待機中...")
+                self.close()
 
     def set_maximum(self, value: int):
         self.progressBar.setMaximum(value)

--- a/progress_dialog.py
+++ b/progress_dialog.py
@@ -51,6 +51,20 @@ class ProgressDialog(QDialog):
                 self.abortButton.setText("中断待機中...")
                 self.close()
 
+    def warning_tiles(self, message):
+        if QMessageBox.No == QMessageBox.question(
+            self,
+            "確認",
+            message,
+            QMessageBox.Yes,
+            QMessageBox.No,
+        ):
+            if self.abortButton.isEnabled():  # abort if possible
+                self.set_abort_flag_callback()
+                self.abortButton.setEnabled(False)
+                self.abortButton.setText("中断待機中...")
+                self.close()
+
     def set_maximum(self, value: int):
         self.progressBar.setMaximum(value)
 

--- a/progress_dialog.py
+++ b/progress_dialog.py
@@ -1,0 +1,67 @@
+import os
+
+# QGIS-API
+from qgis.PyQt import uic
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QKeyEvent
+from PyQt5.QtWidgets import QDialog, QMessageBox
+
+
+class ProgressDialog(QDialog):
+    def __init__(self, set_abort_flag_callback):
+        """_summary_
+
+        Args:
+            set_abort_flag_callback (optional, method()): called when abort clicked
+        """
+        super().__init__()
+        self.setWindowFlag(Qt.WindowCloseButtonHint, False)
+        self.setWindowFlag(Qt.WindowStaysOnTopHint)
+        self.ui = uic.loadUi(
+            os.path.join(os.path.dirname(__file__), "progress_dialog.ui"), self
+        )
+
+        self.set_abort_flag_callback = set_abort_flag_callback
+        self.init_ui()
+
+    def init_ui(self):
+        self.label.setText("処理開始中...")
+        self.progressBar.setValue(0)
+        self.progressBar.setMaximum(0)
+        self.abortButton.setEnabled(True)
+        self.abortButton.setText("中断")
+        self.abortButton.clicked.connect(self.on_abort_click)
+
+    def keyPressEvent(self, event: QKeyEvent):
+        if event.key() == Qt.Key_Escape:
+            return
+        super().keyPressEvent(event)
+
+    def on_abort_click(self):
+        if QMessageBox.Yes == QMessageBox.question(
+            self,
+            "確認",
+            "処理を中断し、以降の処理をスキップしてよろしいですか？",
+            QMessageBox.Yes,
+            QMessageBox.No,
+        ):
+            if self.abortButton.isEnabled():  # abort if possible
+                self.set_abort_flag_callback()
+                self.abortButton.setEnabled(False)
+                self.abortButton.setText("中断待機中...")
+
+    def set_maximum(self, value: int):
+        self.progressBar.setMaximum(value)
+
+    def add_progress(self, value: int):
+        self.progressBar.setValue(self.progressBar.value() + value)
+
+    def set_message(self, message: str):
+        self.label.setText(message)
+
+    def set_abortable(self, abortable=True):
+        self.abortButton.setEnabled(abortable)
+
+    def close_dialog(self):
+        print("closing")
+        self.ui.close()

--- a/progress_dialog.py
+++ b/progress_dialog.py
@@ -36,20 +36,6 @@ class ProgressDialog(QDialog):
             return
         super().keyPressEvent(event)
 
-    def on_abort_click(self):
-        if QMessageBox.Yes == QMessageBox.question(
-            self,
-            "確認",
-            "処理を中断し、以降の処理をスキップしてよろしいですか？",
-            QMessageBox.Yes,
-            QMessageBox.No,
-        ):
-            if self.abortButton.isEnabled():  # abort if possible
-                self.set_abort_flag_callback()
-                self.abortButton.setEnabled(False)
-                self.abortButton.setText("中断待機中...")
-                self.close()
-
     def abort_dialog(self):
         if self.abortButton.isEnabled():  # abort if possible
             self.set_abort_flag_callback()

--- a/progress_dialog.ui
+++ b/progress_dialog.ui
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>300</width>
+    <height>87</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>300</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>処理中...</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QProgressBar" name="progressBar">
+     <property name="minimum">
+      <number>0</number>
+     </property>
+     <property name="maximum">
+      <number>100</number>
+     </property>
+     <property name="value">
+      <number>0</number>
+     </property>
+     <property name="textVisible">
+      <bool>true</bool>
+     </property>
+     <property name="invertedAppearance">
+      <bool>false</bool>
+     </property>
+     <property name="textDirection">
+      <enum>QProgressBar::TopToBottom</enum>
+     </property>
+     <property name="format">
+      <string>%v/%m</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>テキスト</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="abortButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>中断</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #34 

### Description（変更内容）
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<!-- 何のために、どのような変更をしますか？ -->
タイル数を進捗バーを表示
![image](https://github.com/MIERUNE/ElevationTile4JP/assets/26103833/3828e38c-fa92-42c1-9de5-f067fc463fa4)


### Manual Testing（手動テスト）
<!-- If manual testing is required, please describe the procedure. -->
<!-- 手動での動作確認が必要なら、そのやり方を記述してください。-->
Test with various patterns:

- Over 1000 tiles : error message and no process
- between 100 and 999 tiles : warning message and YES: process with progress bar
- between 100 and 999 tiles : warning message and NO: no process
- Try to abort process from progress bar


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - `ElevationTileConverter`クラスが`QThread`を継承するように変更され、スレッド操作を処理するためのシグナルとメソッドが追加されました。
  - 新しい属性として`abort_flag`、`np_array`が追加されました。
  - 進捗ダイアログを備えたカスタム進捗ダイアログが導入されました。
- **改善**
  - タイル数の計算方法が`count_tiles`メソッドに変更され、タイルの検証ロジックが削除されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->