### PR TITLE
Fix/check output path

### DIFF
--- a/get_tiles.py
+++ b/get_tiles.py
@@ -129,16 +129,16 @@ class GetTilesWithinMapCanvas:
 
         # 入力値のバリデーション
         if geotiff_output_path == "":
-            self.iface.messageBar().pushWarning(
-                "ElevationTile4JP", "出力ファイル名を指定してください。"
+            QMessageBox.information(
+                None, "エラー", "出力ファイル名を指定してください。"
             )
             return
 
         # check if directory exists
         directory = os.path.dirname(geotiff_output_path)
         if not os.path.isdir(directory):
-            self.iface.messageBar().pushWarning(
-                "ElevationTile4JP", f"出力フォルダー先が存在していません。\n{directory}"
+            QMessageBox.information(
+                None, "エラー", f"出力フォルダー先が存在していません。\n{directory}"
             )
             return
 
@@ -148,8 +148,9 @@ class GetTilesWithinMapCanvas:
 
         output_crs_isvalid = output_crs.isValid()
         if not output_crs_isvalid:
-            self.iface.messageBar().pushWarning(
-                "ElevationTile4JP",
+            QMessageBox.information(
+                None,
+                "エラー",
                 "出力ファイルの座標系が指定されていません。座標系を指定してください。",
             )
             return
@@ -157,8 +158,9 @@ class GetTilesWithinMapCanvas:
         # 標準時子午線を跨ぐ領域指定はタイルを取得できないので処理を中断する
         xmin, _, xmax, _ = bbox
         if xmin > xmax:
-            self.iface.messageBar().pushWarning(
-                "ElevationTile4JP",
+            QMessageBox.information(
+                None,
+                "エラー",
                 "タイル取得範囲が不正です。マップキャンバスには標準時子午線を跨がない範囲を表示してください。",
             )
             return

--- a/get_tiles.py
+++ b/get_tiles.py
@@ -134,6 +134,18 @@ class GetTilesWithinMapCanvas:
             )
             return
 
+        # check if directory exists
+        directory = os.path.dirname(geotiff_output_path)
+        if not os.path.isdir(directory):
+            self.iface.messageBar().pushWarning(
+                "ElevationTile4JP", f"出力フォルダー先が存在していません。\n{directory}"
+            )
+            return
+
+        # Add .tiff to output path if missing
+        if not geotiff_output_path.lower().endswith(".tiff"):
+            geotiff_output_path += ".tiff"
+
         output_crs_isvalid = output_crs.isValid()
         if not output_crs_isvalid:
             self.iface.messageBar().pushWarning(


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #32 

### Description（変更内容）
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<!-- 何のために、どのような変更をしますか？ -->

- Fix errors when set output path manually

### Manual Testing（手動テスト）
<!-- If manual testing is required, please describe the procedure. -->
<!-- 手動での動作確認が必要なら、そのやり方を記述してください。-->

- Set unexisting folder manually and check error

![image](https://github.com/MIERUNE/ElevationTile4JP/assets/26103833/b73e0825-157b-43a0-9749-a9cf87b46d16)

![image](https://github.com/MIERUNE/ElevationTile4JP/assets/26103833/622dd527-2046-45bd-b965-6db4d809898e)

- Set output path without .tiff extension and check .tiff file is produced or not
![image](https://github.com/MIERUNE/ElevationTile4JP/assets/26103833/5ef51fde-e55c-4dcc-b7ff-adf4ee61fc76)

![image](https://github.com/MIERUNE/ElevationTile4JP/assets/26103833/76849be9-2e31-4ade-b04b-d756d009d46d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 出力ディレクトリの存在確認を追加。
  - 出力パスが「.tiff」で終わることを確認。
  - より情報量のあるエラーメッセージを表示する機能を追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->