### PR TITLE
Progress bar not stay on top

### DIFF
--- a/progress_dialog.py
+++ b/progress_dialog.py
@@ -4,7 +4,7 @@ import os
 from qgis.PyQt import uic
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QKeyEvent
-from PyQt5.QtWidgets import QDialog, QMessageBox
+from PyQt5.QtWidgets import QDialog
 
 
 class ProgressDialog(QDialog):
@@ -16,7 +16,6 @@ class ProgressDialog(QDialog):
         """
         super().__init__()
         self.setWindowFlag(Qt.WindowCloseButtonHint, False)
-        self.setWindowFlag(Qt.WindowStaysOnTopHint)
         self.ui = uic.loadUi(
             os.path.join(os.path.dirname(__file__), "progress_dialog.ui"), self
         )


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #40 

### Manual Testing（手動テスト）
<!-- If manual testing is required, please describe the procedure. -->
<!-- 手動での動作確認が必要なら、そのやり方を記述してください。-->
Widnows環境
進捗バーに処理を停止ボタンを押すときに確認メッセージが裏にならないのを確認

Issue↓
![image](https://github.com/MIERUNE/ElevationTile4JP/assets/26103833/a29b9b4f-6382-4a15-a59f-de9b5aeec3ca)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 進行ダイアログが常に最前面に表示されないように修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->